### PR TITLE
add support for coverlay.el

### DIFF
--- a/vs-light-theme.el
+++ b/vs-light-theme.el
@@ -166,6 +166,11 @@
  `(preview-it-background ((t :background "#E9EAED")))
  )
 
+(custom-theme-set-variables
+ ;; coverlay overlays
+ `(coverlay:tested-line-background-color   "#e1ffe1")
+ `(coverlay:untested-line-background-color "LavenderBlush"))
+
 ;;;###autoload
 (when load-file-name
   (add-to-list 'custom-theme-load-path

--- a/vs-light-theme.el
+++ b/vs-light-theme.el
@@ -167,8 +167,9 @@
  )
 
 (custom-theme-set-variables
+ 'vs-light
  ;; coverlay overlays
- `(coverlay:tested-line-background-color   "#e1ffe1")
+ `(coverlay:tested-line-background-color   "#E1FFE1")
  `(coverlay:untested-line-background-color "LavenderBlush"))
 
 ;;;###autoload


### PR DESCRIPTION
[coverlay](https://github.com/twada/coverlay.el/) is a package which renders overlays showing lines covered (and uncovered) by a project's tests.  overlay background colors are controlled by two `defcustom`s which have default values that don't look great when combined with this theme:
![image](https://user-images.githubusercontent.com/2667110/177016831-19a2a685-deeb-449f-bbfe-2ec4e04fc0a9.png)

I couldn't seem to find a code-coverage feature in vscode from which I could borrow any colors, so I have just taken the default coverlay colors and softened them up:
![image](https://user-images.githubusercontent.com/2667110/177016846-ec0d38a0-b817-47f3-816f-dea6bcc0ba97.png)

thanks for considering!